### PR TITLE
ci: add support for laravel 13

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,6 @@
 name: tests
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   tests:
@@ -10,15 +10,27 @@ jobs:
       fail-fast: true
       matrix:
         php: [8.2, 8.3, 8.4, 8.5]
-        laravel: [11.*, 12.*]
+        laravel: [11.*, 12.*, 13.*]
+        phpunit: [11.*, 12.*]
         dependency-version: [prefer-lowest, prefer-stable]
         include:
           - laravel: 11.*
             testbench: 9.*
           - laravel: 12.*
             testbench: 10.*
+          - laravel: 13.*
+            testbench: 11.*
+        exclude:
+          - laravel: 11.*
+            phpunit: 12.*
+          - laravel: 12.*
+            phpunit: 12.*
+          - laravel: 13.*
+            phpunit: 11.*
+          - laravel: 13.*
+            php: 8.2
 
-    name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
+    name: P${{ matrix.php }} - L${{ matrix.laravel }} - U${{ matrix.phpunit }} - ${{ matrix.dependency-version }}
 
     steps:
       - name: Checkout code
@@ -33,7 +45,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
+          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "phpunit/phpunit:${{ matrix.phpunit }}" --no-interaction --no-update
           composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction
 
       - name: Execute tests

--- a/composer.json
+++ b/composer.json
@@ -22,14 +22,14 @@
     ],
     "require": {
         "php": "^8.2",
-        "illuminate/support": "^11.0|^12.0",
+        "illuminate/support": "^11.0|^12.0|^13.0",
         "spatie/laravel-html": "^3.2"
     },
     "require-dev": {
         "exolnet/phpcs-config": "^2.0",
         "mockery/mockery": "^1.5.1",
-        "orchestra/testbench": "^9.0|^10.0",
-        "phpunit/phpunit": "^11.5.3",
+        "orchestra/testbench": "^9.0|^10.0|^11.0",
+        "phpunit/phpunit": "^11.5.3|^12.0",
         "squizlabs/php_codesniffer": "^3.6"
     },
     "autoload": {


### PR DESCRIPTION
Ref #58942

This pull request updates the package to support Laravel 13 and PHPUnit 12, and improves the test workflow to ensure compatibility across a wider range of PHP, Laravel, and PHPUnit versions. The most important changes are grouped below.

**Testing Workflow Improvements:**

* The GitHub Actions workflow (`.github/workflows/tests.yml`) now allows manual triggering via `workflow_dispatch` for more flexible test runs.
* The test matrix has been expanded to include Laravel 13 and PHPUnit 12, with appropriate exclusions to avoid unsupported version combinations. The job naming has also been updated to reflect the PHPUnit version.
* The workflow now explicitly requires the correct PHPUnit version during dependency installation to match the test matrix.

**Dependency Updates for Compatibility:**

* The `composer.json` file has been updated to support `illuminate/support` v13, `orchestra/testbench` v11, and `phpunit/phpunit` v12, ensuring compatibility with the latest Laravel and PHPUnit releases.